### PR TITLE
2+ fingers roll around camera forward direction

### DIFF
--- a/CameraSpinControls.js
+++ b/CameraSpinControls.js
@@ -28,14 +28,20 @@ CameraSpinControls = function ( camera, domElement ) {
 	// Set to false to disable this control
 	this.enabled = true;
 
+	this.distanceFromPivot = 500;
+
 	this.object = camera;
 	// "target" sets the location of focus, where the object orbits around
 	this.targetObj = new THREE.Object3D();
-	this.targetObj.lookAt(camera.position);
 	this.target = this.targetObj.position;
-	this.distanceFromPivot = this.target.distanceTo( camera.position );
+	
+	if ( camera.position.length() < EPS ) {
+		camera.position.set(0, 0, 1);
+	}	
 
-	this.isTargetOffCenter = false;
+	this.targetObj.lookAt(camera.position);
+
+	this.isTargetOffCenter = true;
 	this.trackballToObject = new THREE.Matrix4();
 
 	this.targetObj.updateWorldMatrix(true, false);
@@ -43,10 +49,9 @@ CameraSpinControls = function ( camera, domElement ) {
 	transformTo(this.trackballToObject, this.targetObj.matrixWorld, this.object.matrixWorld);
 
 	// How far you can dolly in and out ( PerspectiveCamera only )
-	// If isTargetOffCenter === true, will cause jumps if target is closer or further than limits
+	// Will cause jumps if target is moved closer or further than limits
 	this.minDistance = 0;
 	this.maxDistance = Infinity;
-	// TODO If rotate or pan with intersection, ignore rotation distance clamps
 
 	// How far you can zoom in and out ( OrthographicCamera only )
 	this.minZoom = 0;
@@ -165,7 +170,6 @@ CameraSpinControls = function ( camera, domElement ) {
 				scope.trackballToObject.setPosition(v);
 				scope.object.matrix.copy( scope.targetObj.matrixWorld );
 				scope.object.matrix.multiply(scope.trackballToObject);
-
 
 			} else {
 
@@ -891,7 +895,8 @@ CameraSpinControls = function ( camera, domElement ) {
 			scope.spinControl.enabled = true;
 			scope.spinControl.handleTouchStart( event );
 
-		} else {
+		} else if( event.touches.length === 0 ) {
+		// } else {
 			
 			state = STATE.NONE;
 			endEvent.state = state;
@@ -934,19 +939,6 @@ CameraSpinControls = function ( camera, domElement ) {
     	scope.dispatchEvent( changeEvent );
 
   	} );
-  
-	scope.spinControl.addEventListener( 'start', function ( event ) {
-
-		scope.dispatchEvent( startEvent );
-
-	} );
-  
-	scope.spinControl.addEventListener( 'end', function ( event ) {
-
-		endEvent.state = state;
-		scope.dispatchEvent( endEvent );
-
-	} );
 	
 	// Starts touch interfaces off right
 	this.ajustTrackballRadius();

--- a/CameraSpinControls.js
+++ b/CameraSpinControls.js
@@ -802,45 +802,40 @@ CameraSpinControls = function ( camera, domElement ) {
 
 		event.preventDefault();
 
-		switch ( event.touches.length ) {
+		if ( event.touches.length === 1 ) {
+			// 1 finger touch: rotate
+			if ( scope.enableRotate === false ) return;
 
-			case 1:	// one-fingered touch: rotate
+			state = STATE.ROTATE;
+			
+			if ( scope.startTrackballScreenCenter ) {
 
-				if ( scope.enableRotate === false ) return;
+				scope.target.setFromMatrixPosition(scope.trackballToObject);
+				var startDistance = scope.target.length();
+				scope.target.set(0, 0, -startDistance);
+				scope.target.applyQuaternion(scope.object.quaternion);
+				scope.target.add(scope.object.position);
+				scope.setTargetPosition(scope.target);
 
-				state = STATE.ROTATE;
-				
-				if ( scope.startTrackballScreenCenter ) {
+			}
 
-					scope.target.setFromMatrixPosition(scope.trackballToObject);
-					var startDistance = scope.target.length();
-					scope.target.set(0, 0, -startDistance);
-					scope.target.applyQuaternion(scope.object.quaternion);
-					scope.target.add(scope.object.position);
-					scope.setTargetPosition(scope.target);
+		} else if ( event.touches.length >= 2 ) {
+			
+			// 2+ finger touch: dolly-pan
+		
+			if ( scope.enableZoom === false 
+				&& scope.enablePan === false 
+				&& scope.enableRotate === false) return;
 
-				}
+			handleTouchStartDollyPanRoll( event );
 
-				break;
+			state = STATE.TOUCH_DOLLY_PAN;
 
-			case 2:	// two-fingered touch: dolly-pan
+			scope.spinControl.cancelSpin();
+			scope.spinControl.enabled = false;
+		} else {
 
-				if ( scope.enableZoom === false 
-					&& scope.enablePan === false 
-					&& scope.enableRotate === false) return;
-
-				handleTouchStartDollyPanRoll( event );
-
-				state = STATE.TOUCH_DOLLY_PAN;
-
-				scope.spinControl.cancelSpin();
-				scope.spinControl.enabled = false;
-
-				break;
-
-			default:
-
-				state = STATE.NONE;
+			state = STATE.NONE;
 
 		}
 
@@ -859,27 +854,19 @@ CameraSpinControls = function ( camera, domElement ) {
 		event.preventDefault();
 		event.stopPropagation();
 
-		switch ( event.touches.length ) {
+		if ( event.touches.length >= 2) {
 
-			// case 1: // one-fingered touch: rotate
+			// dolly-pan
+			if ( scope.enableZoom === false && scope.enablePan === false ) return;
 
-			// 	if ( scope.enableRotate === false ) return;
+			handleTouchMoveDollyPanRoll( event );
 
-			// 	break;
+		} else {
 
-			case 2: // two-fingered touch: dolly-pan
-
-				if ( scope.enableZoom === false && scope.enablePan === false ) return;
-
-				handleTouchMoveDollyPanRoll( event );
-
-				break;
-
-			default:
-
-				state = STATE.NONE;
+			state = STATE.NONE;
 
 		}
+		// 1 finger touch events are consumed by underlying SpinControls
 
 	}
 
@@ -887,30 +874,41 @@ CameraSpinControls = function ( camera, domElement ) {
 
 		if ( scope.enabled === false ) return;
 
-		if( event.touches.length === 1 ) {
-			
-			state = STATE.ROTATE;
-			scope.spinControl.enabled = true;
-			scope.spinControl.handleTouchStart( event );
-
-		} else if( event.touches.length === 0 ) {
-		// } else {
+		if( event.touches.length === 0 ) {
 			
 			state = STATE.NONE;
 			endEvent.state = state;
 			scope.dispatchEvent( endEvent );
 
+		} else if( event.touches.length === 1 ) {
+
+			if ( scope.startTrackballScreenCenter ) {
+
+				// Set pivot point back to center if going from 2+ fingers to 1
+				scope.target.setFromMatrixPosition(scope.trackballToObject);
+				var startDistance = scope.target.length();
+				scope.target.set(0, 0, -startDistance);
+				scope.target.applyQuaternion(scope.object.quaternion);
+				scope.target.add(scope.object.position);
+				scope.setTargetPosition(scope.target);
+
+			}
+			
+			state = STATE.ROTATE;
+			scope.spinControl.enabled = true;
+			scope.spinControl.handleTouchStart( event );
+
+		} else if( event.touches.length >= 2 ) {
+
+			handleTouchStartDollyPanRoll( event );
+
 		}
-		
 
 	}
 
 	function onContextMenu( event ) {
 
 		event.preventDefault();
-		// if ( scope.enabled === false ) return;
-
-		// event.preventDefault();
 
 	}
 

--- a/SpinControls.js
+++ b/SpinControls.js
@@ -592,7 +592,7 @@ var SpinControls = function ( object, trackBallRadius, camera, domElement ) {
 	}
 
 	function onTouchMove( event ) {
-		
+
 		if ( _this.enabled === false || !_isPointerDown ) return;
 
 		event.preventDefault();
@@ -604,7 +604,7 @@ var SpinControls = function ( object, trackBallRadius, camera, domElement ) {
 
 	function onTouchEnd( event ) {
 
-		if( _this.enabled === false || !_isPointerDown ) return;
+		if( _this.enabled === false ) return;
 
 		if( !_this.hasPointerMovedThisFrame ) {
 			
@@ -615,6 +615,11 @@ var SpinControls = function ( object, trackBallRadius, camera, domElement ) {
 		}
 
 		_this.handlePointerUp( event );
+
+		// override handlePointerUp if finger still down
+		if( event.touches.length > 0 ) {
+			_isPointerDown = true;
+		}
 
 	}
 

--- a/SpinControls.js
+++ b/SpinControls.js
@@ -232,6 +232,8 @@ var SpinControls = function ( object, trackBallRadius, camera, domElement ) {
 
 	}() );
 
+	this.getPointerInNdc = getPointerInNdc; // Handy for CameraSpinControls
+
 	// Find vector from object to pointer in screen space
 	var getObjectToPointer = ( function () { 
 
@@ -248,7 +250,7 @@ var SpinControls = function ( object, trackBallRadius, camera, domElement ) {
 			_this.camera.updateWorldMatrix( true, false );
 			// Need to update camera.matrixWorldInverse if camera moved before renderer.render
 			_this.camera.matrixWorldInverse.copy( _this.camera.matrixWorld ).invert();
-			objPos.project( _this.camera ); // position in ndc/screen			
+			objPos.project( _this.camera ); // position in ndc/screen
 			objToPointer.set( objPos.x, objPos.y ); 
 			objToPointer.subVectors( pointerNdcScreen, objToPointer ); 
 

--- a/example_camera_spin.html
+++ b/example_camera_spin.html
@@ -54,8 +54,9 @@
 
 				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 10000 );
 
+				camera.position.set(0, 0, 500);
+
 				cameraSpinControl = new CameraSpinControls( camera, renderer.domElement );
-				cameraSpinControl.distanceFromPivot = 500;
 
 				// Uncomment for third person view of CameraSpinControls 
 				// And comment out CameraSpinControls above 

--- a/index.html
+++ b/index.html
@@ -255,7 +255,9 @@
 				trackballWidget.renderOrder = 1; // Don't draw to early, thus obscuring other transparent objects        
 				
 				controls = new CameraSpinControls( camera, renderer.domElement );
-				controls.isTargetOffCenter = true;
+				// Moving trackball position to mesh intersection points
+				// so disable controls moving trackball on rotation start
+				controls.startTrackballScreenCenter = false; 
 
 				var raycaster = new THREE.Raycaster();
 				var pointerPos = new THREE.Vector2();
@@ -271,25 +273,22 @@
 
 				function onPointerDown() {
 
-					if (controls.isTargetOffCenter) {
+					raycaster.setFromCamera( pointerPos, camera );
+					var intersects = raycaster.intersectObjects( cameraPivotSurfaces );
 
-						raycaster.setFromCamera( pointerPos, camera );
-						var intersects = raycaster.intersectObjects( cameraPivotSurfaces );					
+					if(intersects.length) {
 
-						if(intersects.length) {
+						controls.setTargetPosition(intersects[0].point);
 
-							controls.setTargetPosition(intersects[0].point);
+					} else {
 
-						} else {
-
-							// Move trackball to center of screen if not clicking on anything.
-							// Comment out to rotate with trackball centered on mouse.
-							controls.target.set(0, 0, -controls.distanceFromPivot);
-							controls.target.applyQuaternion(camera.quaternion);
-							controls.target.add(camera.position);
-							controls.setTargetPosition(controls.target);
-
-						}
+						// Move trackball to center of screen if not clicking on anything.
+						controls.target.setFromMatrixPosition(controls.trackballToObject);
+						var startDistance = controls.target.length();
+						controls.target.set(0, 0, -startDistance);
+						controls.target.applyQuaternion(camera.quaternion);
+						controls.target.add(camera.position);
+						controls.setTargetPosition(controls.target);
 
 					}
 

--- a/index.html
+++ b/index.html
@@ -126,11 +126,11 @@
 			<h1 class="menuTitle">SpinControls</h1>
 			<div id="settings">
 				<p>
-					Left click or touch spheres to rotate them as if touching a trackball.
+					Click spheres to rotate.  Click colorful knot to rotate about intersection point.
 				</p>
 				<p><strong>Camera</strong> | Orbit: Left click / 1 finger | Pan: Right click / 2 fingers | Zoom: Mouse wheel / pinch</p>
 				<p>
-					<label for="mapping">Pointer to trackball sphere mapping method: 
+					<label for="mapping">Pointer to trackball mapping method: 
 						<select id="spin-mapping" class="clickable">
 							<option value="raycast">Raycast</option>
 							<option value="holroyd">Holroyd</option>
@@ -216,7 +216,8 @@
 				
 				spinControlSmall = new SpinControls( smallSpinner, radius, camera, renderer.domElement );
 				spinControlSmall.spinAxisConstraint = spinAxis;
-				spinControlSmall.dampingFactor = 1.5;
+				spinControlSmall.dampingFactor = 1.5; // Decreases to keep spinning longer after pointer release. Default is 1.0
+				spinControlSmall.rotateSensitivity = .8; // Increase for faster spin. Multiplies pointer movement to ball rotation.
         
 				var radius = 200;
 				bigSpinner = new THREE.Group();

--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@
 				window.addEventListener( 'wheel', onMouseWheel, true );
 				window.addEventListener( 'wheel', onMouseWheelOff, false );
 				
-				renderer.domElement.addEventListener( 'touchstart', onTouchStart, false );
+				renderer.domElement.addEventListener( 'touchstart', onTouchStart, true ); // catch down to enable camera control
 				window.addEventListener( 'touchend', onTouchEnd, false ); // get event last, so false on capture
 
 				// Spheres to spin


### PR DESCRIPTION
For touchscreen control to feel right, need to rotate the camera about its Z axis when 2 or more fingers are down.

Removed the CameraSpinControls::distanceToPivot property.  The camera offset from pivot/target is set by the translation from the origin to the camera on CameraSpinControls construction.